### PR TITLE
added OWASP java-html-sanitizer to prevent xss injections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,11 @@
             <version>1.13.1</version>
         </dependency>
         <dependency>
+		    <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+		    <artifactId>owasp-java-html-sanitizer</artifactId>
+		    <version>20191001.1</version>
+		</dependency>
+        <dependency>
             <groupId>com.atlassian.plugin</groupId>
             <artifactId>atlassian-spring-scanner-annotation</artifactId>
             <version>${atlassian.spring.scanner.version}</version>

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/MarkdownFromURLMacro.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/MarkdownFromURLMacro.java
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.ArrayList;
 import java.util.List;
@@ -50,6 +49,9 @@ import java.nio.charset.StandardCharsets;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.*;
 import org.jsoup.select.*;
+
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
 
 public class MarkdownFromURLMacro extends BaseMacro implements Macro {
 
@@ -190,7 +192,23 @@ public class MarkdownFromURLMacro extends BaseMacro implements Macro {
 							image.attr("src", new URL(importFrom, src).toString());
 						}
 					}
-					html =  body.html() +  highlightjs + highlightjscss;
+					
+			        PolicyFactory policy = new HtmlPolicyBuilder()
+			        		.allowCommonInlineFormattingElements()
+			        		.allowCommonBlockElements()
+			        		.allowStyling()
+			        		.allowStandardUrlProtocols()
+			        		.allowElements("a", "table", "tr", "td", "th", "thead", "tbody", "img", "hr", "input", "code", "pre", "dl", "dt", "dd")
+			        	    .allowAttributes("href").onElements("a")
+					        .allowAttributes("align", "class").onElements("table", "tr", "td", "th", "thead", "tbody")
+			        		.allowAttributes("id").onElements("h1", "h2", "h3", "h4", "h5", "h6", "sup", "li")
+			        	    .allowAttributes("alt", "src").onElements("img")
+			        	    .allowAttributes("class").onElements("li", "code")
+			        	    .allowAttributes("type", "class", "checked", "disabled", "readonly").onElements("input")
+					        .allowTextIn("table")
+			        		.toFactory();
+			        String sanitizedBody = policy.sanitize(body.html());
+			        html =  sanitizedBody +  highlightjs + highlightjscss;
 
 					return html;
 				}


### PR DESCRIPTION
I fixed the missing class issue we were running into before by deleting the whole target folder before running atlas-package. Maybe running atlas-clean between each atlas-package would also fix this, but the plugin never broke again so I wasn't able to test that.