### PR TITLE
Relative paths for Azure DevOps support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,13 @@
 		  <version>4.4.0</version>
 		  <scope>provided</scope>
 		</dependency>
+
+        <dependency>
+            <groupId>com.atlassian.plugins.rest</groupId>
+            <artifactId>atlassian-rest-common</artifactId>
+            <version>2.9.7</version>
+            <scope>provided</scope>
+        </dependency>
         
         <dependency>
             <groupId>com.atlassian.confluence</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,9 @@
                     <productDataVersion>${confluence.data.version}</productDataVersion>
                     <enableQuickReload>true</enableQuickReload>
                     <enableFastdev>false</enableFastdev>
+                    <compressJs>false</compressJs>
+                    <compressCss>false</compressCss>
+                    <compressResources>false</compressResources>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/MarkdownFromURLMacro.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/MarkdownFromURLMacro.java
@@ -239,7 +239,7 @@ public class MarkdownFromURLMacro extends BaseMacro implements Macro {
 
 			Boolean linkifyHeaders = Boolean.parseBoolean(parameters.containsKey("LinkifyHeaders") ? parameters.get("LinkifyHeaders") : "true");
 			Boolean useRelativePathsAzureDevOps = parameters.containsKey("LinkAzureDevOpsRepository")
-					? !MarkdownRelativePathsDevOpsHelper.IsNullOrEmpty(parameters.get("LinkAzureDevOpsRepository"))
+					? !MarkdownRelativePathsDevOpsHelper.isNullOrEmpty(parameters.get("LinkAzureDevOpsRepository"))
 					: false;
 
 			List<Extension> extensions = new ArrayList<>();

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/MarkdownFromURLMacro.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/MarkdownFromURLMacro.java
@@ -238,7 +238,9 @@ public class MarkdownFromURLMacro extends BaseMacro implements Macro {
 			}
 
 			Boolean linkifyHeaders = Boolean.parseBoolean(parameters.containsKey("LinkifyHeaders") ? parameters.get("LinkifyHeaders") : "true");
-			Boolean useRelativePathsAzureDevOps = Boolean.parseBoolean(parameters.containsKey("UseAzureDevOpsRelativePathUrls") ? parameters.get("UseAzureDevOpsRelativePathUrls") : "false");
+			Boolean useRelativePathsAzureDevOps = parameters.containsKey("LinkAzureDevOpsRepository")
+					? !MarkdownRelativePathsDevOpsHelper.IsNullOrEmpty(parameters.get("LinkAzureDevOpsRepository"))
+					: false;
 
 			List<Extension> extensions = new ArrayList<>();
 			extensions.add(TablesExtension.create());

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/MarkdownFromURLMacro.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/MarkdownFromURLMacro.java
@@ -238,9 +238,7 @@ public class MarkdownFromURLMacro extends BaseMacro implements Macro {
 			}
 
 			Boolean linkifyHeaders = Boolean.parseBoolean(parameters.containsKey("LinkifyHeaders") ? parameters.get("LinkifyHeaders") : "true");
-			Boolean useRelativePathsAzureDevOps = parameters.containsKey("LinkAzureDevOpsRepository")
-					? !MarkdownRelativePathsDevOpsHelper.isNullOrEmpty(parameters.get("LinkAzureDevOpsRepository"))
-					: false;
+			Boolean useRelativePathsAzureDevOps = Boolean.parseBoolean(parameters.containsKey("UseAzureDevOpsRelativePathUrls") ? parameters.get("UseAzureDevOpsRelativePathUrls") : "false");
 
 			List<Extension> extensions = new ArrayList<>();
 			extensions.add(TablesExtension.create());

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/MarkdownFromURLMacro.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/MarkdownFromURLMacro.java
@@ -237,6 +237,7 @@ public class MarkdownFromURLMacro extends BaseMacro implements Macro {
 				e.printStackTrace();
 			}
 
+			Boolean linkifyHeaders = Boolean.parseBoolean(parameters.containsKey("LinkifyHeaders") ? parameters.get("LinkifyHeaders") : "true");
 			Boolean useRelativePathsAzureDevOps = Boolean.parseBoolean(parameters.containsKey("UseAzureDevOpsRelativePathUrls") ? parameters.get("UseAzureDevOpsRelativePathUrls") : "false");
 
 			List<Extension> extensions = new ArrayList<>();

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/MarkdownRelativeDevOpsUrls.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/MarkdownRelativeDevOpsUrls.java
@@ -1,0 +1,129 @@
+package com.atlassian.plugins.confluence.markdown;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.vladsch.flexmark.ast.Image;
+import com.vladsch.flexmark.ast.Link;
+import com.vladsch.flexmark.ast.Reference;
+import com.vladsch.flexmark.ext.autolink.AutolinkExtension;
+import com.vladsch.flexmark.ext.autolink.internal.AutolinkNodePostProcessor;
+import com.vladsch.flexmark.ext.jekyll.tag.JekyllTag;
+import com.vladsch.flexmark.ext.jekyll.tag.JekyllTagBlock;
+import com.vladsch.flexmark.html.HtmlRenderer.Builder;
+import com.vladsch.flexmark.html.HtmlRenderer.HtmlRendererExtension;
+import com.vladsch.flexmark.html.LinkResolver;
+import com.vladsch.flexmark.html.LinkResolverFactory;
+
+import com.vladsch.flexmark.html.renderer.LinkResolverBasicContext;
+import com.vladsch.flexmark.html.renderer.LinkStatus;
+import com.vladsch.flexmark.html.renderer.LinkType;
+import com.vladsch.flexmark.html.renderer.ResolvedLink;
+import com.vladsch.flexmark.util.ast.Node;
+import com.vladsch.flexmark.util.data.DataHolder;
+import com.vladsch.flexmark.util.data.DataKey;
+import com.vladsch.flexmark.util.data.MutableDataHolder;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class MarkdownRelativeDevOpsUrls {
+    public static String relativePathDataKey = "";
+    public static String devOpsUrlDataKey = "";
+
+    public static class DocxLinkResolver implements LinkResolver {
+        private Path markdownPath;
+        private final String devOpsUrl;
+
+        public DocxLinkResolver(LinkResolverBasicContext context) {
+            try {
+                markdownPath = Paths.get(relativePathDataKey);
+            } catch (Exception e) {
+                markdownPath = null;
+            }
+
+            devOpsUrl = devOpsUrlDataKey;
+        }
+
+        @NotNull
+        @Override
+        public ResolvedLink resolveLink(@NotNull Node node, @NotNull LinkResolverBasicContext context, @NotNull ResolvedLink link) {
+            if (node instanceof Image || node instanceof Link || node instanceof Reference || node instanceof JekyllTag) {
+                String url = link.getUrl();
+
+                if (url.startsWith("http://") || url.startsWith("https://") || url.startsWith("ftp://") || url.startsWith("sftp://")) {
+                    // resolve url, return one of LinkStatus other than LinkStatus.UNKNOWN
+                    return link.withStatus(LinkStatus.VALID)
+                            .withUrl(url);
+                } else if (url.startsWith("file:/")) {
+                    // assume it is good
+                    return link.withStatus(LinkStatus.VALID)
+                            .withUrl(url);
+                } else if (url.startsWith("www.")) {
+                    // should be prefixed with http://, we will just add it
+                    return link.withStatus(LinkStatus.INVALID)
+                            .withUrl("http://" + url);
+                } else if (url.startsWith("./")) {
+                    if (devOpsUrl.equals("null") || markdownPath.toString() == null) {
+                        return link.withStatus(LinkStatus.INVALID);
+                    }
+
+                    // relative paths processed here
+                    Path joinedPath = MarkdownRelativePathsDevOpsHelper.combinePaths(markdownPath, url);
+
+                    String formatToUrlPath = joinedPath.toString();
+                    formatToUrlPath = formatToUrlPath.replace("\\", "%2F");
+
+                    link = link.withStatus(LinkStatus.VALID)
+                            .withLinkType(LinkType.LINK)
+                            .withUrl(devOpsUrl + "?path=" + formatToUrlPath);
+                }
+            }
+
+            return link;
+        }
+
+        public static class Factory implements LinkResolverFactory {
+            @Nullable
+            @Override
+            public Set<Class<?>> getAfterDependents() {
+                return null;
+            }
+
+            @Nullable
+            @Override
+            public Set<Class<?>> getBeforeDependents() {
+                return null;
+            }
+
+            @Override
+            public boolean affectsGlobalScope() {
+                return false;
+            }
+
+            @NotNull
+            @Override
+            public LinkResolver apply(@NotNull LinkResolverBasicContext context) {
+                return new DocxLinkResolver(context);
+            }
+        }
+    }
+
+    static class CustomExtension implements HtmlRendererExtension {
+        @Override
+        public void rendererOptions(@NotNull MutableDataHolder options) {
+
+        }
+
+        @Override
+        public void extend(@NotNull Builder htmlRendererBuilder, @NotNull String rendererType) {
+            htmlRendererBuilder.linkResolverFactory(new DocxLinkResolver.Factory());
+        }
+
+        public static CustomExtension create() {
+            return new CustomExtension();
+        }
+    }
+}

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/MarkdownRelativeDevOpsUrls.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/MarkdownRelativeDevOpsUrls.java
@@ -65,7 +65,7 @@ public class MarkdownRelativeDevOpsUrls {
                     // should be prefixed with http://, we will just add it
                     return link.withStatus(LinkStatus.INVALID)
                             .withUrl("http://" + url);
-                } else if (url.startsWith("./")) {
+                } else {
                     if (devOpsUrl.equals("null") || markdownPath.toString() == null) {
                         return link.withStatus(LinkStatus.INVALID);
                     }

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/MarkdownRelativePathsDevOpsHelper.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/MarkdownRelativePathsDevOpsHelper.java
@@ -1,0 +1,33 @@
+package com.atlassian.plugins.confluence.markdown;
+
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class MarkdownRelativePathsDevOpsHelper {
+    public static Path getPathFromRawMarkdownUrl(URL url) {
+        String strUrl = url.toString();
+        int start = strUrl.indexOf("path") + 5;
+        int end = strUrl.indexOf(".md", start) + 3;
+
+        String extractedPath = strUrl.substring(start, end);
+        return Paths.get(extractedPath.replace("%2F", "/"));
+    }
+
+    public static Path getPathFromRawMarkdownUrlAsBodyContent(String strUrl) {
+        int start = strUrl.indexOf("path") + 5;
+        int end = strUrl.indexOf(".md", start) + 3;
+
+        String extractedPath = strUrl.substring(start, end);
+        return Paths.get(extractedPath.replace("%2F", "/"));
+    }
+
+    public static Path combinePaths(Path mainPath, String relativePathStr){
+        relativePathStr = relativePathStr.substring(2);
+        Path relativePath = Paths.get(relativePathStr);
+
+        mainPath = mainPath.getParent();
+
+        return mainPath.resolve(relativePath);
+    }
+}

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/MarkdownRelativePathsDevOpsHelper.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/MarkdownRelativePathsDevOpsHelper.java
@@ -30,4 +30,10 @@ public class MarkdownRelativePathsDevOpsHelper {
 
         return mainPath.resolve(relativePath);
     }
+
+
+    public static boolean IsNullOrEmpty(String str)
+    {
+        return str == null || str.isEmpty();
+    }
 }

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/MarkdownRelativePathsDevOpsHelper.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/MarkdownRelativePathsDevOpsHelper.java
@@ -32,7 +32,7 @@ public class MarkdownRelativePathsDevOpsHelper {
     }
 
 
-    public static boolean IsNullOrEmpty(String str)
+    public static boolean isNullOrEmpty(String str)
     {
         return str == null || str.isEmpty();
     }

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/configuration/MarkdownConfigModel.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/configuration/MarkdownConfigModel.java
@@ -6,6 +6,15 @@ import java.util.List;
 public class MarkdownConfigModel {
     private List<String> whitelist = new ArrayList<String>();
     private boolean enabled = false;
+    private boolean isAzureDevOpsEnabled = false;
+
+    public boolean getIsAzureDevOpsEnabled(){
+        return isAzureDevOpsEnabled;
+    }
+
+    public void setIsAzureDevOpsEnabled(boolean isAzureDevOpsEnabled){
+        this.isAzureDevOpsEnabled = isAzureDevOpsEnabled;
+    }
 
     public List<String> getWhitelist() {
         return whitelist;
@@ -32,6 +41,7 @@ public class MarkdownConfigModel {
     	
     	if (((MarkdownConfigModel) o).getEnabled() != this.enabled) return false;
     	if (!((MarkdownConfigModel) o).getWhitelist().equals(this.whitelist)) return false;
+        if (((MarkdownConfigModel) o).getIsAzureDevOpsEnabled() != this.isAzureDevOpsEnabled) return false;
     	
     	return true;
     }

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/configuration/PluginAdminGetConfigurationAction.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/configuration/PluginAdminGetConfigurationAction.java
@@ -1,20 +1,33 @@
 package com.atlassian.plugins.confluence.markdown.configuration;
 
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
 import com.atlassian.bandana.BandanaManager;
 import com.atlassian.confluence.core.ConfluenceActionSupport;
 import com.atlassian.confluence.setup.bandana.ConfluenceBandanaContext;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ConfluenceImport;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+@Path("/config")
 public class PluginAdminGetConfigurationAction extends ConfluenceActionSupport {
     public static final String PLUGIN_CONFIG_KEY = "markdown-plugin-config-00";
 
+    @ConfluenceImport
     private BandanaManager bandanaManager;
     private ConfluenceBandanaContext context = new ConfluenceBandanaContext("markdown-plugin");
     private ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     
     private MacroConfigModel model;
+
+    public PluginAdminGetConfigurationAction(BandanaManager bandanaManager){
+        this.bandanaManager = bandanaManager;
+    }
 
     @Override
     public String doDefault() throws Exception {
@@ -35,5 +48,27 @@ public class PluginAdminGetConfigurationAction extends ConfluenceActionSupport {
 
     public String getData() throws JsonProcessingException {
         return objectMapper.writeValueAsString(model);
+    }
+
+    @Path("/retrieve")
+    @GET
+    @Produces({MediaType.APPLICATION_JSON})
+    public Response getMarkdownConfig()
+    {
+        String config = (String) bandanaManager.getValue(context, PLUGIN_CONFIG_KEY);
+
+        model = new MacroConfigModel();
+        if (config != null && !config.trim().isEmpty() && !"null".equalsIgnoreCase(config)) {
+            try{
+                model = objectMapper.readValue(config, MacroConfigModel.class);
+            } catch (Exception e) {
+                model = new MacroConfigModel();
+            }
+        }
+        if (model == null) {
+            model = new MacroConfigModel();
+        }
+
+        return Response.ok( model.getConfig().getIsAzureDevOpsEnabled() ).build();
     }
 }

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -43,7 +43,6 @@
         <category name="formatting"/>
         <parameters>
             <parameter name="LinkifyHeaders" type="boolean" default="true" />
-            <parameter name="UseAzureDevOpsRelativePathUrls" type="boolean" default="false" />
             <parameter name="LinkAzureDevOpsRepository" type="string" default="" />
         </parameters>
 	</xhtml-macro>
@@ -56,7 +55,6 @@
         <category name="formatting"/>
         <parameters>
             <parameter name="LinkifyHeaders" type="boolean" default="true" />
-            <parameter name="UseAzureDevOpsRelativePathUrls" type="boolean" default="false" />
             <parameter name="LinkAzureDevOpsRepository" type="string" default="" />
         </parameters>
     </macro>

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -43,6 +43,7 @@
         <category name="formatting"/>
         <parameters>
             <parameter name="LinkifyHeaders" type="boolean" default="true" />
+            <parameter name="UseAzureDevOpsRelativePathUrls" type="boolean" default="false" />
             <parameter name="LinkAzureDevOpsRepository" type="string" default="" />
         </parameters>
 	</xhtml-macro>
@@ -55,6 +56,7 @@
         <category name="formatting"/>
         <parameters>
             <parameter name="LinkifyHeaders" type="boolean" default="true" />
+            <parameter name="UseAzureDevOpsRelativePathUrls" type="boolean" default="false" />
             <parameter name="LinkAzureDevOpsRepository" type="string" default="" />
         </parameters>
     </macro>

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -37,7 +37,12 @@
                  icon="/download/resources/com.atlassian.plugins.confluence.markdown.confluence-markdown-macro/images/pluginIcon.png"
                  documentation-url="https://spec.commonmark.org/0.28/">
         <category name="formatting"/>
-        <parameters />
+        <parameters>
+            <parameter name="UseAzureDevOpsRelativePathUrls" type="boolean" default="false">
+            </parameter>
+            <parameter name="LinkAzureDevOpsRepository" type="string" default="">
+            </parameter>
+        </parameters>
 	</xhtml-macro>
 	
     <macro name="markdown-from-url"
@@ -46,7 +51,12 @@
            icon="/download/resources/com.atlassian.plugins.confluence.markdown.confluence-markdown-macro/images/pluginIcon.png"
            documentation-url="https://spec.commonmark.org/0.28/">
         <category name="formatting"/>
-        <parameters />
+        <parameters>
+            <parameter name="UseAzureDevOpsRelativePathUrls" type="boolean" default="false">
+            </parameter>
+            <parameter name="LinkAzureDevOpsRepository" type="string" default="">
+            </parameter>
+        </parameters>
     </macro>
     
     <web-section key="markdown-macro-admin-section" name="Markdown Macro admin section" location="system.admin" weight="10">

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -104,5 +104,15 @@
             </action>
         </package>
     </xwork>
-	
+
+    <rest key="markdown-from-url-rest-endpoint" path="/markdown-from-url" version="1.0">
+        <description>Markdown From Url REST Endpoint</description>
+    </rest>
+
+    <web-resource key="hidden-field-parameter" name="Add a hidden field">
+        <resource type="download" name="hidden-parameter-field.js" location="js/hidden-parameter-field.js" />
+        <dependency>confluence.editor.actions:editor-macro-browser</dependency>
+        <context>macro-browser</context>
+    </web-resource>
+
 </atlassian-plugin>

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -42,9 +42,14 @@
                  documentation-url="https://spec.commonmark.org/0.28/">
         <category name="formatting"/>
         <parameters>
-            <parameter name="LinkifyHeaders" type="boolean" default="true" />
-            <parameter name="UseAzureDevOpsRelativePathUrls" type="boolean" default="false" />
-            <parameter name="LinkAzureDevOpsRepository" type="string" default="" />
+            <parameter name="LinkifyHeaders" type="boolean" default="true">
+                <option key="showNameInPlaceholder" value="false" />
+                <option key="showValueInPlaceholder" value="false" />
+            </parameter>
+            <parameter name="LinkAzureDevOpsRepository" type="string" default="">
+                <option key="showNameInPlaceholder" value="false" />
+                <option key="showValueInPlaceholder" value="false" />
+            </parameter>
         </parameters>
 	</xhtml-macro>
 	
@@ -55,9 +60,14 @@
            documentation-url="https://spec.commonmark.org/0.28/">
         <category name="formatting"/>
         <parameters>
-            <parameter name="LinkifyHeaders" type="boolean" default="true" />
-            <parameter name="UseAzureDevOpsRelativePathUrls" type="boolean" default="false" />
-            <parameter name="LinkAzureDevOpsRepository" type="string" default="" />
+            <parameter name="LinkifyHeaders" type="boolean" default="true">
+                <option key="showNameInPlaceholder" value="false" />
+                <option key="showValueInPlaceholder" value="false" />
+            </parameter>
+            <parameter name="LinkAzureDevOpsRepository" type="string" default="">
+                <option key="showNameInPlaceholder" value="false" />
+                <option key="showValueInPlaceholder" value="false" />
+            </parameter>
         </parameters>
     </macro>
     

--- a/src/main/resources/js/hidden-parameter-field.js
+++ b/src/main/resources/js/hidden-parameter-field.js
@@ -1,0 +1,45 @@
+function processParameter(param, paramType) {
+    var requestUrl = AJS.contextPath() + '/rest/markdown-from-url/1.0/config/retrieve';
+
+    // sync request for first loading params, then rendering edit-macro
+    var request = new XMLHttpRequest();
+    request.open('GET', requestUrl, false);
+    request.send(null);
+
+    var parameterField = AJS.MacroBrowser.ParameterFields[paramType](param, {});
+
+    if (request.status === 200) {
+        parameterField = hideParameter(param, parameterField, !(request.responseText === "true"));
+    }
+
+    return parameterField;
+}
+
+/// hides parameter field if it is needed
+function hideParameter(param, parameterField, toHide){
+    if (toHide){
+        var parameterField = AJS.MacroBrowser.ParameterFields["_hidden"](param, {});
+
+        if (!parameterField.getValue()) {
+            // by default placing false value
+            parameterField.setValue("false");
+        }
+    }
+
+    return parameterField;
+}
+
+AJS.MacroBrowser.setMacroJsOverride("markdown-from-url", {
+    fields: {
+        string: {
+            "LinkAzureDevOpsRepository": function (param) {
+                return processParameter(param, "string");
+            }
+        },
+        boolean: {
+            "UseAzureDevOpsRelativePathUrls": function (param) {
+                return processParameter(param, "boolean");
+            }
+        }
+    }
+});

--- a/src/main/resources/js/hidden-parameter-field.js
+++ b/src/main/resources/js/hidden-parameter-field.js
@@ -21,8 +21,8 @@ function hideParameter(param, parameterField, toHide){
         var parameterField = AJS.MacroBrowser.ParameterFields["_hidden"](param, {});
 
         if (!parameterField.getValue()) {
-            // by default placing false value
-            parameterField.setValue("false");
+            // by default placing null value
+            parameterField.setValue(null);
         }
     }
 
@@ -34,11 +34,6 @@ AJS.MacroBrowser.setMacroJsOverride("markdown-from-url", {
         string: {
             "LinkAzureDevOpsRepository": function (param) {
                 return processParameter(param, "string");
-            }
-        },
-        boolean: {
-            "UseAzureDevOpsRelativePathUrls": function (param) {
-                return processParameter(param, "boolean");
             }
         }
     }

--- a/src/main/resources/js/markdown-configure.js
+++ b/src/main/resources/js/markdown-configure.js
@@ -2,6 +2,8 @@ AJS.toInit(function ($) {
     var sJson = $("#data").val();
     var json = JSON.parse(sJson);
 
+    $("#azure-customs-enabled").attr("checked", json.config.isAzureDevOpsEnabled);
+
 	if (json.config.enabled) {
 		$("#whitelist-enabled").attr("checked", true);
 		$("#list-input").attr("disabled", false);
@@ -49,7 +51,8 @@ AJS.toInit(function ($) {
         var json = {
             "config": {
                 "whitelist": getIPPatterns("list-list"),
-				"enabled": document.getElementById("whitelist-enabled").checked
+				"enabled": document.getElementById("whitelist-enabled").checked,
+                "isAzureDevOpsEnabled": document.getElementById("azure-customs-enabled").checked
             },
 			"changed": false
         };

--- a/src/main/resources/markdown-from-url-properties/markdown-from-url.properties
+++ b/src/main/resources/markdown-from-url-properties/markdown-from-url.properties
@@ -2,3 +2,6 @@ com.atlassian.plugins.confluence.markdown.confluence-markdown-macro.markdown-fro
 com.atlassian.plugins.confluence.markdown.confluence-markdown-macro.markdown-from-url.desc=This macro dynamically imports Markdown from a URL and renders it into HTML.
 com.atlassian.plugins.confluence.markdown.admin.section.label=Markdown Macro
 com.atlassian.plugins.confluence.markdown.admin.config.label=Configuration
+com.atlassian.plugins.confluence.markdown.confluence-markdown-macro.markdown-from-url.param.UseAzureDevOpsRelativePathUrls.label=Render relative-path links to AzureDevOps repository
+com.atlassian.plugins.confluence.markdown.confluence-markdown-macro.markdown-from-url.param.LinkAzureDevOpsRepository.label=Link to Azure DevOps Repository
+com.atlassian.plugins.confluence.markdown.confluence-markdown-macro.markdown-from-url.param.LinkAzureDevOpsRepository.desc=(https://azure-domain/tfs/project/_git/repo)

--- a/src/main/resources/markdown-from-url-properties/markdown-from-url.properties
+++ b/src/main/resources/markdown-from-url-properties/markdown-from-url.properties
@@ -3,6 +3,5 @@ com.atlassian.plugins.confluence.markdown.confluence-markdown-macro.markdown-fro
 com.atlassian.plugins.confluence.markdown.admin.section.label=Markdown Macro
 com.atlassian.plugins.confluence.markdown.admin.config.label=Configuration
 com.atlassian.plugins.confluence.markdown.confluence-markdown-macro.markdown-from-url.param.LinkifyHeaders.label=Render headers as anchors
-com.atlassian.plugins.confluence.markdown.confluence-markdown-macro.markdown-from-url.param.UseAzureDevOpsRelativePathUrls.label=Render relative-path links to AzureDevOps repository
-com.atlassian.plugins.confluence.markdown.confluence-markdown-macro.markdown-from-url.param.LinkAzureDevOpsRepository.label=Link to Azure DevOps Repository
-com.atlassian.plugins.confluence.markdown.confluence-markdown-macro.markdown-from-url.param.LinkAzureDevOpsRepository.desc=(https://azure-domain/tfs/project/_git/repo)
+com.atlassian.plugins.confluence.markdown.confluence-markdown-macro.markdown-from-url.param.LinkAzureDevOpsRepository.label=Base URL for AzureDevOps
+com.atlassian.plugins.confluence.markdown.confluence-markdown-macro.markdown-from-url.param.LinkAzureDevOpsRepository.desc=If you are using AzureDevOps, configuring this value fixes relative links. Eg: https://azure-domain/tfs/project/_git/repo

--- a/src/main/resources/markdown-macro-config.vm
+++ b/src/main/resources/markdown-macro-config.vm
@@ -30,7 +30,7 @@
 	        <p>Changes saved successfully.</p>
 	    </div>
 
-        <p style="padding: 10px 0;">Enable Azure DevOps custom relative path resolution. Otherwise classic github-style relative path support is used.</p>
+        <h3 style="padding: 10px 0;">Enable Azure DevOps custom relative path resolution. Otherwise classic github-style relative path support is used.</h3>
 
         <div class="flex-box">
             <div class="checkbox">
@@ -39,7 +39,9 @@
             </div>
         </div>
 
-        <p style="padding: 10px 0;">Enable URL Whitelist feature. If not enabled, all domains will be allowed.</p>
+        <div class="clearer"></div>
+
+        <h3 style="padding: 10px 0;">Enable URL Whitelist feature. If not enabled, all domains will be allowed.</h3>
         
         <div class="flex-box">
             <div class="checkbox">

--- a/src/main/resources/markdown-macro-config.vm
+++ b/src/main/resources/markdown-macro-config.vm
@@ -29,7 +29,16 @@
 	    <div class="aui-message aui-message-confirmation" id="save-success-popup" style="display: none;">
 	        <p>Changes saved successfully.</p>
 	    </div>
-        
+
+        <p style="padding: 10px 0;">Enable Azure DevOps custom relative path resolution. Otherwise classic github-style relative path support is used.</p>
+
+        <div class="flex-box">
+            <div class="checkbox">
+                <input type="checkbox" id="azure-customs-enabled" class="checkbox" name="azure-customs-enabled">
+                <label for="azure-customs-enabled">Enable Azure DevOps Relative Paths for Markdown From Url Macro</label>
+            </div>
+        </div>
+
         <p style="padding: 10px 0;">Enable URL Whitelist feature. If not enabled, all domains will be allowed.</p>
         
         <div class="flex-box">


### PR DESCRIPTION
If user wants to use any relative to markdown paths it is possible to check 'Render relative-path links to AzureDevOps repository' and write down full link to root of DevOps repository
![image](https://user-images.githubusercontent.com/31598696/87067594-f72cc280-c21c-11ea-9b25-8a936b85527a.png)

The links combine as system files are doing it.
For example markdown can be placed at '?path=%2Finfrastructure%2Ftest%2F!README.md' (**\infrastructure\test\README.md**) and in markdown there is a relative link **(./UI)**.
So pathCombine should be **\infrastructure\test\UI**.

Paths would be combined and final link would be something like this:
<url-to-root-of-repository>?path=combine(markdownPath, url)