### PR TITLE
Fix confluence 6.13.6 admin-config page

### DIFF
--- a/src/main/java/com/atlassian/plugins/confluence/markdown/configuration/PluginAdminGetConfigurationAction.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/configuration/PluginAdminGetConfigurationAction.java
@@ -25,10 +25,6 @@ public class PluginAdminGetConfigurationAction extends ConfluenceActionSupport {
     
     private MacroConfigModel model;
 
-    public PluginAdminGetConfigurationAction(BandanaManager bandanaManager){
-        this.bandanaManager = bandanaManager;
-    }
-
     @Override
     public String doDefault() throws Exception {
         String config = (String) bandanaManager.getValue(context, PLUGIN_CONFIG_KEY);


### PR DESCRIPTION
Hello, @bberenberg!
I've read Your [issue](https://github.com/Atlas-Authority/MarkdownMacro/issues/26) and tried to fix this.
To be honest I hadn't succeeded in reproducing this error but I believe this small fix could work that trouble out.

As I understand, constructor injection is not supported, so I've deleted constructor for controller that I've created in #22.
bandanaManager can be injected by 'setBandanaManager()' setter as it is done in very similar class PluginSaveAdminConfigurationAction https://github.com/Atlas-Authority/MarkdownMacro/blob/34e14d63c65990c254ed10f33879f857802d5391/src/main/java/com/atlassian/plugins/confluence/markdown/configuration/PluginAdminSaveConfigurationAction.java#L38