### PR TITLE
Upgrade all jackson related deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
          <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.10.3</version>
+            <version>2.12.6</version>
         </dependency>
         
         <dependency>
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.10.3</version>
+            <version>2.12.6</version>
         </dependency>
         
         <!-- WIRED TEST RUNNER DEPENDENCIES -->


### PR DESCRIPTION
The PR https://github.com/Atlas-Authority/MarkdownMacro/pull/44/files breaks the plugin. There was some cache on my local system so did not catch this issue when testing the upgrade. I do `mvn clean` last night and found it break.

For the fix, we need to upgrade all Jackson dependencies, not just `databind`