### PR TITLE
Include user who has edit perm in migration payload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,15 @@
                 </configuration>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <filtering>true</filtering>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>confluence-markdown-macro.properties</include>
+                </includes>
+            </resource>
+        </resources>
     </build>
     <properties>
         <java.source.version>1.8</java.source.version>

--- a/pom.xml
+++ b/pom.xml
@@ -252,9 +252,6 @@
             <resource>
                 <filtering>true</filtering>
                 <directory>src/main/resources</directory>
-                <includes>
-                    <include>confluence-markdown-macro.properties</include>
-                </includes>
             </resource>
         </resources>
     </build>

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/MyPluginComponentImpl.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/MyPluginComponentImpl.java
@@ -7,7 +7,6 @@ import com.atlassian.confluence.rest.api.model.ExpansionsParser;
 import com.atlassian.confluence.user.AuthenticatedUserThreadLocal;
 import com.atlassian.confluence.user.ConfluenceUser;
 import com.atlassian.confluence.user.UserAccessor;
-import com.atlassian.confluence.xhtml.api.XhtmlContent;
 import com.atlassian.migration.app.AccessScope;
 import com.atlassian.migration.app.PaginatedMapping;
 import com.atlassian.migration.app.gateway.AppCloudMigrationGateway;
@@ -54,14 +53,14 @@ public class MyPluginComponentImpl implements DiscoverableListener {
             @Value("${build.version}") String serverAppVersion,
             @ConfluenceImport ContentService contentService,
             @ConfluenceImport UserAccessor userAccessor,
-            @ConfluenceImport XhtmlContent xhtmlContent,
+            PageFilter pageFilter,
             SpacePermissionService spacePermissionService,
             PageRestrictionService pageRestrictionService,
             UserService userService
     ) {
         this.contentService = contentService;
         this.userAccessor = userAccessor;
-        this.pageFilter = new PageFilter(xhtmlContent);
+        this.pageFilter = pageFilter;
         this.serverAppVersion = serverAppVersion;
         this.spacePermissionService = spacePermissionService;
         this.pageRestrictionService = pageRestrictionService;

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/MyPluginComponentImpl.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/MyPluginComponentImpl.java
@@ -2,17 +2,8 @@ package com.atlassian.plugins.confluence.markdown.ccma;
 
 import com.atlassian.confluence.api.model.content.*;
 import com.atlassian.confluence.api.model.content.id.ContentId;
-import com.atlassian.confluence.api.model.pagination.PageResponse;
-import com.atlassian.confluence.api.model.people.Subject;
-import com.atlassian.confluence.api.model.people.SubjectType;
-import com.atlassian.confluence.api.model.people.User;
-import com.atlassian.confluence.api.model.permissions.ContentRestriction;
-import com.atlassian.confluence.api.model.permissions.OperationKey;
 import com.atlassian.confluence.api.service.content.ContentService;
 import com.atlassian.confluence.rest.api.model.ExpansionsParser;
-import com.atlassian.confluence.security.SpacePermission;
-import com.atlassian.confluence.spaces.Space;
-import com.atlassian.confluence.spaces.SpaceManager;
 import com.atlassian.confluence.user.AuthenticatedUserThreadLocal;
 import com.atlassian.confluence.user.ConfluenceUser;
 import com.atlassian.confluence.user.UserAccessor;
@@ -37,8 +28,6 @@ import javax.inject.Named;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static com.atlassian.migration.app.AccessScope.*;
@@ -48,29 +37,35 @@ import static com.atlassian.migration.app.AccessScope.*;
 public class MyPluginComponentImpl implements DiscoverableListener {
 
     private static final Logger log = LoggerFactory.getLogger(MyPluginComponentImpl.class);
-    private static final String USER_MAPPING_PREFIX = "confluence.userkey/";
     private static final int BATCH_SIZE = 5;
 
-    @ConfluenceImport private final SpaceManager spaceManager;
-    @ConfluenceImport private final ContentService contentService;
-    @ConfluenceImport private final UserAccessor userAccessor;
+    private final ContentService contentService;
+    private final UserAccessor userAccessor;
+
     private final PageFilter pageFilter;
     private final String serverAppVersion;
+
+    private final SpacePermissionService spacePermissionService;
+    private final PageRestrictionService pageRestrictionService;
+    private final UserService userService;
 
     @Inject
     public MyPluginComponentImpl(
             @Value("${build.version}") String serverAppVersion,
-            @ConfluenceImport SpaceManager spaceManager,
             @ConfluenceImport ContentService contentService,
             @ConfluenceImport UserAccessor userAccessor,
-            @ConfluenceImport XhtmlContent xhtmlContent
+            @ConfluenceImport XhtmlContent xhtmlContent,
+            SpacePermissionService spacePermissionService,
+            PageRestrictionService pageRestrictionService,
+            UserService userService
     ) {
-        // It is not safe to save a direct reference to the gateway as that can change over time
-        this.spaceManager = spaceManager;
         this.contentService = contentService;
         this.userAccessor = userAccessor;
         this.pageFilter = new PageFilter(xhtmlContent);
         this.serverAppVersion = serverAppVersion;
+        this.spacePermissionService = spacePermissionService;
+        this.pageRestrictionService = pageRestrictionService;
+        this.userService = userService;
     }
 
     @Override
@@ -84,29 +79,35 @@ public class MyPluginComponentImpl implements DiscoverableListener {
             final ObjectMapper objectMapper = new ObjectMapper();
             log.info("Migration context summary: " + objectMapper.writeValueAsString(migrationDetails));
 
-            final Map<String, String> userMap = getUserMap(gateway, transferId);
-
             final List<PageData> pageDataList = getPageDataList(gateway, transferId);
 
-            final Set<Long> spaceIds = pageDataList
-                    .stream()
-                    .map(PageData::getServerSpaceId)
-                    .collect(Collectors.toSet());
+            final Map<String, String> userMap = userService.getUserMap(gateway, transferId);
 
-            final Map<Long, Set<UserKey>> spaceUsersById = getSpacePermissions(spaceIds);
+            final Map<Long, Set<UserKey>> spacePermissions = spacePermissionService.getPermissions(pageDataList);
+
+            final Map<String, Set<UserKey>> pageRestrictions = pageRestrictionService.getPermissions(pageDataList);
 
             final ObjectMapper overallMapper = new ObjectMapper();
             final ObjectNode topLevelNode = overallMapper.createObjectNode();
 
+            topLevelNode.put("serverAppVersion", serverAppVersion);
+
             final ArrayNode pagesNode = topLevelNode.putArray("pages");
+            final ArrayNode cloudPageIdsNode = topLevelNode.putArray("cloudPageId");
             for (PageData pageData: pageDataList) {
                 final ObjectNode page = pagesNode.addObject();
-                final String userCloudKey = pickUserWhoHasEditPerm(pageData, spaceUsersById, userMap);
+                final String userCloudKey = userService.pickUserWhoHasEditPerm(
+                        pageData,
+                        spacePermissions,
+                        pageRestrictions,
+                        userMap
+                );
+
+                cloudPageIdsNode.add(pageData.getCloudId());
+
                 page.put("pageId", pageData.getCloudId());
                 page.put("accountId", userCloudKey);
             }
-
-            topLevelNode.put("serverAppVersion", serverAppVersion);
 
             stream.write(overallMapper.writeValueAsString(topLevelNode).getBytes(StandardCharsets.UTF_8));
         } catch (Exception e) {
@@ -153,38 +154,14 @@ public class MyPluginComponentImpl implements DiscoverableListener {
      * Check if a server page is latest and needs migrate.
      */
     private Optional<PageData> getLatestPageData(String serverPageId, String cloudPageId) {
-        final Optional<Content> pageOpt = contentService
+        return contentService
                 .find(ExpansionsParser.parse("history,body.storage,space,restrictions.update.restrictions.user"))
                 .withType(ContentType.PAGE)
                 .withId(ContentId.of(Long.parseLong(serverPageId)))
-                .fetch();
-
-        return pageOpt
+                .fetch()
                 .filter(this::isLatestVersion)
                 .filter(this::hasMarkdownMarcoFromUrl)
-                .map(page -> {
-                    final List<Subject> restrictedUsers = Optional.ofNullable(page.getRestrictions())
-                            .map(restrictions -> restrictions.get(OperationKey.UPDATE))
-                            .map(ContentRestriction::getRestrictions)
-                            .map(restrictions -> restrictions.get(SubjectType.USER))
-                            .map(PageResponse::getResults)
-                            .orElse(Collections.emptyList());
-
-                    final Set<UserKey> restrictedUserKeys = restrictedUsers
-                            .stream()
-                            .map(subject -> (User) subject)
-                            .map(User::optionalUserKey)
-                            .filter(Optional::isPresent)
-                            .map(Optional::get)
-                            .collect(Collectors.toSet());
-
-                    return new PageData(
-                            cloudPageId,
-                            page.getSpace().getId(),
-                            page.getBody().get(ContentRepresentation.STORAGE).getValue(),
-                            restrictedUserKeys
-                    );
-                });
+                .map(page -> new PageData(serverPageId, cloudPageId, page.getSpace().getId(), page));
     }
 
     private boolean isLatestVersion(Content page) {
@@ -207,83 +184,7 @@ public class MyPluginComponentImpl implements DiscoverableListener {
                 .isPresent();
     }
 
-    /**
-     * Pick a user who has edit permission on page.
-     *
-     * Return null if the permission is not controlled at user level:
-     * <li>Space is public and allows anonymous access (global space permission) OR</li>
-     * <li>Space permissions are controlled at group level. In this case, since cloud app has
-     * READ and WRITE scope so it totally has access to space content.</li>
-     */
-    private String pickUserWhoHasEditPerm(
-            PageData pageData,
-            Map<Long, Set<UserKey>> spaceUsersById,
-            Map<String, String> userMap
-    ) {
-        Optional<UserKey> userKeyOpt;
-        final Set<UserKey> pageRestrictedUsers = pageData.getRestrictedUserKeys();
-        if (!pageRestrictedUsers.isEmpty()) {
-            // if this page has update restriction config then pick user from it
-            userKeyOpt = pageRestrictedUsers.stream().findAny();
-        } else {
-            // otherwise pick a user at space level
-            final long spaceId = pageData.getServerSpaceId();
-            userKeyOpt = spaceUsersById
-                    .getOrDefault(spaceId, Collections.emptySet())
-                    .stream()
-                    .findAny();
-        }
 
-        return userKeyOpt
-                .map(UserKey::getStringValue)
-                .map(USER_MAPPING_PREFIX::concat)
-                .map(userMap::get)
-                .orElse(null);
-    }
-
-    /**
-     * Mapping from space server id to a set of users who has edit permission on that space.
-     */
-    private Map<Long, Set<UserKey>> getSpacePermissions(Set<Long> spaceIds) {
-        return spaceIds.stream().collect(Collectors.toMap(Function.identity(), this::getEditSpaceUsers));
-    }
-
-    /**
-     * Get server users who has edit permission on space
-     */
-    private Set<UserKey> getEditSpaceUsers(long spaceId) {
-        final Space space = spaceManager.getSpace(spaceId);
-        if (space == null) {
-            return Collections.emptySet();
-        }
-        final Set<UserKey> userKeys = space.getPermissions().stream()
-                .filter(SpacePermission::isUserPermission)
-                .filter(perm -> SpacePermission.CREATEEDIT_PAGE_PERMISSION.equalsIgnoreCase(perm.getType()))
-                .map(SpacePermission::getUserSubject)
-                .filter(Objects::nonNull)
-                .map(ConfluenceUser::getKey)
-                .collect(Collectors.toSet());
-        return Collections.unmodifiableSet(userKeys);
-    }
-
-    /**
-     * User mapping from server id to cloud id.
-     */
-    private Map<String, String> getUserMap(AppCloudMigrationGateway gateway, String transferId) {
-        final PaginatedMapping paginatedMapping = gateway.getPaginatedMapping(transferId, "identity:user", BATCH_SIZE);
-        final Map<String, String> results = new HashMap<>();
-        while (paginatedMapping.next()) {
-            final Map<String, String> mappings = paginatedMapping.getMapping();
-            for (Map.Entry<String, String> entry : mappings.entrySet()) {
-                String serverUserKey = entry.getKey();
-                String cloudUserKey = entry.getValue();
-                if (serverUserKey.startsWith(USER_MAPPING_PREFIX)) {
-                    results.put(serverUserKey, cloudUserKey);
-                }
-            }
-        }
-        return Collections.unmodifiableMap(results);
-    }
 
     @Override
     public String getCloudAppKey() {

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/MyPluginComponentImpl.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/MyPluginComponentImpl.java
@@ -133,7 +133,7 @@ public class MyPluginComponentImpl implements DiscoverableListener {
      */
     private Optional<PageData> getLatestPageData(String serverPageId, String cloudPageId) {
         return contentService
-                .find(ExpansionsParser.parse("history,body.storage,space,restrictions.update.restrictions.user"))
+                .find(ExpansionsParser.parse("history,body.storage,space,restrictions.update.restrictions.user,restrictions.update.restrictions.group"))
                 .withType(ContentType.PAGE)
                 .withId(ContentId.of(Long.parseLong(serverPageId)))
                 .fetch()

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/PageData.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/PageData.java
@@ -9,34 +9,34 @@ class PageData {
     private final Content page;
     private String cloudUserKey;
 
-    public PageData(String serverId, String cloudId, long serverSpaceId, Content page) {
+    PageData(String serverId, String cloudId, long serverSpaceId, Content page) {
         this.serverId = serverId;
         this.cloudId = cloudId;
         this.serverSpaceId = serverSpaceId;
         this.page = page;
     }
 
-    public String getServerId() {
+    String getServerId() {
         return serverId;
     }
 
-    public String getCloudId() {
+    String getCloudId() {
         return cloudId;
     }
 
-    public long getServerSpaceId() {
+    long getServerSpaceId() {
         return serverSpaceId;
     }
 
-    public Content getPage() {
+    Content getPage() {
         return page;
     }
 
-    public String getCloudUserKey() {
+    String getCloudUserKey() {
         return cloudUserKey;
     }
 
-    public void setCloudUserKey(String cloudUserKey) {
+    void setCloudUserKey(String cloudUserKey) {
         this.cloudUserKey = cloudUserKey;
     }
 }

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/PageData.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/PageData.java
@@ -1,0 +1,36 @@
+package com.atlassian.plugins.confluence.markdown.ccma;
+
+import com.atlassian.sal.api.user.UserKey;
+
+import java.util.Set;
+
+class PageData {
+    private final String cloudId;
+    private final long serverSpaceId;
+    private final String body;
+    private final Set<UserKey> restrictedUserKeys;
+
+
+    public PageData(String cloudId, long serverSpaceId, String body, Set<UserKey> restrictedUserKeys) {
+        this.cloudId = cloudId;
+        this.serverSpaceId = serverSpaceId;
+        this.body = body;
+        this.restrictedUserKeys = restrictedUserKeys;
+    }
+
+    public String getCloudId() {
+        return cloudId;
+    }
+
+    public long getServerSpaceId() {
+        return serverSpaceId;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public Set<UserKey> getRestrictedUserKeys() {
+        return restrictedUserKeys;
+    }
+}

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/PageData.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/PageData.java
@@ -1,21 +1,18 @@
 package com.atlassian.plugins.confluence.markdown.ccma;
 
+import com.atlassian.confluence.api.model.content.Content;
 import com.atlassian.sal.api.user.UserKey;
 
 import java.util.Set;
 
 class PageData {
+    private final String serverId;
     private final String cloudId;
     private final long serverSpaceId;
-    private final String body;
-    private final Set<UserKey> restrictedUserKeys;
+    private final Content page;
 
-
-    public PageData(String cloudId, long serverSpaceId, String body, Set<UserKey> restrictedUserKeys) {
-        this.cloudId = cloudId;
-        this.serverSpaceId = serverSpaceId;
-        this.body = body;
-        this.restrictedUserKeys = restrictedUserKeys;
+    public String getServerId() {
+        return serverId;
     }
 
     public String getCloudId() {
@@ -26,11 +23,14 @@ class PageData {
         return serverSpaceId;
     }
 
-    public String getBody() {
-        return body;
+    public Content getPage() {
+        return page;
     }
 
-    public Set<UserKey> getRestrictedUserKeys() {
-        return restrictedUserKeys;
+    public PageData(String serverId, String cloudId, long serverSpaceId, Content page) {
+        this.serverId = serverId;
+        this.cloudId = cloudId;
+        this.serverSpaceId = serverSpaceId;
+        this.page = page;
     }
 }

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/PageData.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/PageData.java
@@ -1,15 +1,20 @@
 package com.atlassian.plugins.confluence.markdown.ccma;
 
 import com.atlassian.confluence.api.model.content.Content;
-import com.atlassian.sal.api.user.UserKey;
-
-import java.util.Set;
 
 class PageData {
     private final String serverId;
     private final String cloudId;
     private final long serverSpaceId;
     private final Content page;
+    private String cloudUserKey;
+
+    public PageData(String serverId, String cloudId, long serverSpaceId, Content page) {
+        this.serverId = serverId;
+        this.cloudId = cloudId;
+        this.serverSpaceId = serverSpaceId;
+        this.page = page;
+    }
 
     public String getServerId() {
         return serverId;
@@ -27,10 +32,11 @@ class PageData {
         return page;
     }
 
-    public PageData(String serverId, String cloudId, long serverSpaceId, Content page) {
-        this.serverId = serverId;
-        this.cloudId = cloudId;
-        this.serverSpaceId = serverSpaceId;
-        this.page = page;
+    public String getCloudUserKey() {
+        return cloudUserKey;
+    }
+
+    public void setCloudUserKey(String cloudUserKey) {
+        this.cloudUserKey = cloudUserKey;
     }
 }

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/PageFilter.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/PageFilter.java
@@ -3,12 +3,18 @@ package com.atlassian.plugins.confluence.markdown.ccma;
 import com.atlassian.confluence.content.render.xhtml.DefaultConversionContext;
 import com.atlassian.confluence.content.render.xhtml.XhtmlException;
 import com.atlassian.confluence.xhtml.api.XhtmlContent;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ConfluenceImport;
 import com.atlassian.renderer.RenderContext;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Named
 class PageFilter {
     private final XhtmlContent xhtmlContent;
 
-    PageFilter(XhtmlContent xhtmlContent) {
+    @Inject
+    PageFilter(@ConfluenceImport XhtmlContent xhtmlContent) {
         this.xhtmlContent = xhtmlContent;
     }
 

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/PageFilter.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/PageFilter.java
@@ -1,0 +1,36 @@
+package com.atlassian.plugins.confluence.markdown.ccma;
+
+import com.atlassian.confluence.content.render.xhtml.DefaultConversionContext;
+import com.atlassian.confluence.content.render.xhtml.XhtmlException;
+import com.atlassian.confluence.xhtml.api.XhtmlContent;
+import com.atlassian.renderer.RenderContext;
+
+class PageFilter {
+    private final XhtmlContent xhtmlContent;
+
+    PageFilter(XhtmlContent xhtmlContent) {
+        this.xhtmlContent = xhtmlContent;
+    }
+
+    boolean hasMarkdownMacroFromUrl(String body){
+        return new PageChecker().check(xhtmlContent, body);
+    }
+
+    private static class PageChecker {
+        boolean result = false;
+
+        boolean check(XhtmlContent xhtmlContent, String body) {
+            try {
+                xhtmlContent.handleMacroDefinitions(body, new DefaultConversionContext(
+                        new RenderContext()),
+                        macroDefinition -> result = "markdown-from-url".equals(macroDefinition.getName()
+                        ));
+            } catch (XhtmlException e) {
+                result = false;
+            }
+            return result;
+        }
+    }
+}
+
+

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/PageFilter.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/PageFilter.java
@@ -5,12 +5,16 @@ import com.atlassian.confluence.content.render.xhtml.XhtmlException;
 import com.atlassian.confluence.xhtml.api.XhtmlContent;
 import com.atlassian.plugin.spring.scanner.annotation.imports.ConfluenceImport;
 import com.atlassian.renderer.RenderContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 
 @Named
 class PageFilter {
+    private static final Logger log = LoggerFactory.getLogger(PageFilter.class);
+
     private final XhtmlContent xhtmlContent;
 
     @Inject
@@ -32,6 +36,7 @@ class PageFilter {
                         macroDefinition -> result = "markdown-from-url".equals(macroDefinition.getName()
                         ));
             } catch (XhtmlException e) {
+                log.error("Unable to parse content body", e);
                 result = false;
             }
             return result;

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/PageRestrictionService.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/PageRestrictionService.java
@@ -1,0 +1,71 @@
+package com.atlassian.plugins.confluence.markdown.ccma;
+
+import com.atlassian.confluence.api.model.content.Content;
+import com.atlassian.confluence.api.model.pagination.PageResponse;
+import com.atlassian.confluence.api.model.people.Subject;
+import com.atlassian.confluence.api.model.people.SubjectType;
+import com.atlassian.confluence.api.model.people.User;
+import com.atlassian.confluence.api.model.permissions.ContentRestriction;
+import com.atlassian.confluence.api.model.permissions.OperationKey;
+import com.atlassian.confluence.user.UserAccessor;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ConfluenceImport;
+import com.atlassian.sal.api.user.UserKey;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Named
+class PageRestrictionService extends PermissionService<Content, String> {
+
+    @Inject
+    PageRestrictionService(@ConfluenceImport UserAccessor userAccessor) {
+        super(userAccessor);
+    }
+
+    @Override
+    String key(Content page) {
+        return page.getId().serialise();
+    }
+
+    @Override
+    List<Content> convert(Collection<PageData> pageDataList) {
+        return pageDataList
+                .stream()
+                .map(PageData::getPage)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    Set<String> getEditGroups(Content page) {
+        final List<Subject> groupSubject = Optional
+                .ofNullable(page.getRestrictions())
+                .map(restrictions -> restrictions.get(OperationKey.UPDATE))
+                .map(ContentRestriction::getRestrictions)
+                .map(restrictions -> restrictions.get(SubjectType.GROUP))
+                .map(PageResponse::getResults)
+                .orElse(Collections.emptyList());
+
+        return groupSubject.stream()
+                .map(com.atlassian.confluence.api.model.people.Group.class::cast)
+                .map(com.atlassian.confluence.api.model.people.Group::getName)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    Set<UserKey> getEditUsers(Content page) {
+        final List<Subject> userSubjects = Optional.ofNullable(page.getRestrictions())
+                .map(restrictions -> restrictions.get(OperationKey.UPDATE))
+                .map(ContentRestriction::getRestrictions)
+                .map(restrictions -> restrictions.get(SubjectType.USER))
+                .map(PageResponse::getResults)
+                .orElse(Collections.emptyList());
+        return userSubjects.stream()
+                .map(User.class::cast)
+                .map(User::optionalUserKey)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/PageRestrictionService.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/PageRestrictionService.java
@@ -7,8 +7,6 @@ import com.atlassian.confluence.api.model.people.SubjectType;
 import com.atlassian.confluence.api.model.people.User;
 import com.atlassian.confluence.api.model.permissions.ContentRestriction;
 import com.atlassian.confluence.api.model.permissions.OperationKey;
-import com.atlassian.confluence.user.UserAccessor;
-import com.atlassian.plugin.spring.scanner.annotation.imports.ConfluenceImport;
 import com.atlassian.sal.api.user.UserKey;
 
 import javax.inject.Inject;
@@ -20,8 +18,7 @@ import java.util.stream.Collectors;
 class PageRestrictionService extends PermissionService<Content, String> {
 
     @Inject
-    PageRestrictionService(@ConfluenceImport UserAccessor userAccessor) {
-        super(userAccessor);
+    PageRestrictionService() {
     }
 
     @Override

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/PermData.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/PermData.java
@@ -1,0 +1,30 @@
+package com.atlassian.plugins.confluence.markdown.ccma;
+
+import com.atlassian.sal.api.user.UserKey;
+
+import java.util.Collections;
+import java.util.Set;
+
+class PermData {
+    private final Set<UserKey> users;
+    private final Set<String> groups;
+
+    static final PermData empty = new PermData(Collections.emptySet(), Collections.emptySet());
+
+    PermData(Set<UserKey> users, Set<String> groups) {
+        this.users = users;
+        this.groups = groups;
+    }
+
+    Set<UserKey> getUsers() {
+        return users;
+    }
+
+    Set<String> getGroups() {
+        return groups;
+    }
+
+    boolean isEmpty() {
+        return users.isEmpty() && groups.isEmpty();
+    }
+}

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/PermissionService.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/PermissionService.java
@@ -1,0 +1,77 @@
+package com.atlassian.plugins.confluence.markdown.ccma;
+
+import com.atlassian.confluence.user.ConfluenceUser;
+import com.atlassian.confluence.user.UserAccessor;
+import com.atlassian.sal.api.user.UserKey;
+import com.atlassian.user.Group;
+import org.apache.commons.collections4.SetUtils;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+abstract class PermissionService<E, K> {
+
+    private final UserAccessor userAccessor;
+
+    PermissionService(UserAccessor userAccessor) {
+        this.userAccessor = userAccessor;
+    }
+
+    final Map<K, Set<UserKey>> getPermissions(Collection<PageData> pageDataList) {
+        final List<E> entities = convert(pageDataList);
+
+        final Set<String> groupNames = getEditGroups(entities);
+
+        final Map<String, Set<UserKey>> editUsersByGroupName = getEditUserByGroup(groupNames);
+
+        return entities.stream().collect(Collectors.toMap(
+                this::key,
+                entity -> {
+                    final Set<UserKey> editUsers = getEditUsers(entity);
+                    final Set<String> groups = getEditGroups(entity);
+                    final Set<UserKey> editUsersFromGroups = groups.stream()
+                            .filter(editUsersByGroupName::containsKey)
+                            .map(editUsersByGroupName::get)
+                            .flatMap(Set::stream)
+                            .collect(Collectors.toSet());
+                    return SetUtils.union(editUsers, editUsersFromGroups);
+                }
+        ));
+    }
+
+    /**
+     * Mapping from a group to its users who have edit perm.
+     */
+    private Map<String, Set<UserKey>> getEditUserByGroup(Set<String> groupNames) {
+        return groupNames.stream().collect(Collectors.toMap(
+                Function.identity(),
+                groupName -> {
+                    final Group group = userAccessor.getGroup(groupName);
+                    final Spliterator<ConfluenceUser> spliterator = Spliterators.spliteratorUnknownSize(
+                            userAccessor.getMembers(group).iterator(),
+                            Spliterator.ORDERED
+                    );
+                    return StreamSupport.stream(spliterator, false)
+                            .map(ConfluenceUser::getKey)
+                            .collect(Collectors.toSet());
+                }
+        ));
+    }
+
+    private Set<String> getEditGroups(List<E> entities) {
+        return entities.stream()
+                .map(this::getEditGroups)
+                .flatMap(Set::stream)
+                .collect(Collectors.toSet());
+    }
+
+    abstract K key(E entity);
+
+    abstract List<E> convert(Collection<PageData> pageDataList);
+
+    abstract Set<String> getEditGroups(E entity);
+
+    abstract Set<UserKey> getEditUsers(E entity);
+}

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/PermissionService.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/PermissionService.java
@@ -11,6 +11,11 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+/**
+ * Get all users who has edit permission on wiki objects.
+ * @param <E> The confluence entity (space or page)
+ * @param <K> The confluence entity key type
+ */
 abstract class PermissionService<E, K> {
 
     private final UserAccessor userAccessor;
@@ -19,6 +24,11 @@ abstract class PermissionService<E, K> {
         this.userAccessor = userAccessor;
     }
 
+    /**
+     * For each page, get all users who:
+     * <li>Belong to groups which has edit permission</li>
+     * <li>Are granted edit permission as individual users</li>
+     */
     final Map<K, Set<UserKey>> getPermissions(Collection<PageData> pageDataList) {
         final List<E> entities = convert(pageDataList);
 
@@ -67,11 +77,23 @@ abstract class PermissionService<E, K> {
                 .collect(Collectors.toSet());
     }
 
+    /**
+     * How to retrieve entity key?
+     */
     abstract K key(E entity);
 
+    /**
+     * Get the list of entities where the permission will be extracted from.
+     */
     abstract List<E> convert(Collection<PageData> pageDataList);
 
+    /**
+     * Get all groups which have edit permission on an entity.
+     */
     abstract Set<String> getEditGroups(E entity);
 
+    /**
+     * Get all individual users which have edit permission on an entity.
+     */
     abstract Set<UserKey> getEditUsers(E entity);
 }

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/SpacePermissionService.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/SpacePermissionService.java
@@ -4,7 +4,6 @@ import com.atlassian.confluence.security.SpacePermission;
 import com.atlassian.confluence.spaces.Space;
 import com.atlassian.confluence.spaces.SpaceManager;
 import com.atlassian.confluence.user.ConfluenceUser;
-import com.atlassian.confluence.user.UserAccessor;
 import com.atlassian.plugin.spring.scanner.annotation.imports.ConfluenceImport;
 import com.atlassian.sal.api.user.UserKey;
 
@@ -14,16 +13,12 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 @Named
-public class SpacePermissionService extends PermissionService<Space, Long> {
+class SpacePermissionService extends PermissionService<Space, Long> {
 
     private final SpaceManager spaceManager;
 
     @Inject
-    SpacePermissionService(
-            @ConfluenceImport UserAccessor userAccessor,
-            @ConfluenceImport SpaceManager spaceManager
-    ) {
-        super(userAccessor);
+    SpacePermissionService(@ConfluenceImport SpaceManager spaceManager) {
         this.spaceManager = spaceManager;
     }
 

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/SpacePermissionService.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/SpacePermissionService.java
@@ -1,0 +1,72 @@
+package com.atlassian.plugins.confluence.markdown.ccma;
+
+import com.atlassian.confluence.security.SpacePermission;
+import com.atlassian.confluence.spaces.Space;
+import com.atlassian.confluence.spaces.SpaceManager;
+import com.atlassian.confluence.user.ConfluenceUser;
+import com.atlassian.confluence.user.UserAccessor;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ConfluenceImport;
+import com.atlassian.sal.api.user.UserKey;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Named
+public class SpacePermissionService extends PermissionService<Space, Long> {
+
+    private final SpaceManager spaceManager;
+
+    @Inject
+    SpacePermissionService(
+            @ConfluenceImport UserAccessor userAccessor,
+            @ConfluenceImport SpaceManager spaceManager
+    ) {
+        super(userAccessor);
+        this.spaceManager = spaceManager;
+    }
+
+    @Override
+    Long key(Space space) {
+        return space.getId();
+    }
+
+    @Override
+    List<Space> convert(Collection<PageData> pageDataList) {
+        return pageDataList
+                .stream()
+                .map(PageData::getServerSpaceId)
+                .collect(Collectors.toSet())
+                .stream()
+                .map(spaceManager::getSpace)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    Set<String> getEditGroups(Space space) {
+        return space.getPermissions()
+                .stream()
+                .filter(SpacePermission::isGroupPermission)
+                .filter(this::isEditPermission)
+                .map(SpacePermission::getGroup)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    Set<UserKey> getEditUsers(Space space) {
+        final Set<UserKey> userKeys = space.getPermissions().stream()
+                .filter(SpacePermission::isUserPermission)
+                .filter(this::isEditPermission)
+                .map(SpacePermission::getUserSubject)
+                .filter(Objects::nonNull)
+                .map(ConfluenceUser::getKey)
+                .collect(Collectors.toSet());
+        return Collections.unmodifiableSet(userKeys);
+    }
+
+    private boolean isEditPermission(SpacePermission permission) {
+        return SpacePermission.CREATEEDIT_PAGE_PERMISSION.equalsIgnoreCase(permission.getType());
+    }
+}

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/UserService.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/UserService.java
@@ -1,9 +1,7 @@
 package com.atlassian.plugins.confluence.markdown.ccma;
 
-import com.atlassian.confluence.user.UserAccessor;
 import com.atlassian.migration.app.PaginatedMapping;
 import com.atlassian.migration.app.gateway.AppCloudMigrationGateway;
-import com.atlassian.plugin.spring.scanner.annotation.imports.ConfluenceImport;
 import com.atlassian.sal.api.user.UserKey;
 import org.apache.commons.collections4.SetUtils;
 
@@ -16,8 +14,49 @@ class UserService {
     private static final String USER_MAPPING_PREFIX = "confluence.userkey/";
     private static final int BATCH_SIZE = 5;
 
+    private final SpacePermissionService spacePermissionService;
+    private final PageRestrictionService pageRestrictionService;
+
     @Inject
-    UserService(@ConfluenceImport UserAccessor userAccessor) {
+    UserService(
+            SpacePermissionService spacePermissionService,
+            PageRestrictionService pageRestrictionService
+    ) {
+        this.spacePermissionService = spacePermissionService;
+        this.pageRestrictionService = pageRestrictionService;
+    }
+
+    /**
+     * Populate a use who has edit permission for each page.
+     */
+    void enrichCloudUser(AppCloudMigrationGateway gateway, String transferId, List<PageData> pageDataList) {
+        final Map<String, String> userMap = getUserMap(gateway, transferId);
+        final Map<Long, Set<UserKey>> spacePermissions = spacePermissionService.getPermissions(pageDataList);
+        final Map<String, Set<UserKey>> pageRestrictions = pageRestrictionService.getPermissions(pageDataList);
+
+        for (PageData pageData : pageDataList) {
+            final String cloudUserKey = pickUserWhoHasEditPerm(pageData, spacePermissions, pageRestrictions, userMap);
+            pageData.setCloudUserKey(cloudUserKey);
+        }
+    }
+
+    /**
+     * User mapping from server id to cloud id.
+     */
+    private Map<String, String> getUserMap(AppCloudMigrationGateway gateway, String transferId) {
+        final PaginatedMapping paginatedMapping = gateway.getPaginatedMapping(transferId, "identity:user", BATCH_SIZE);
+        final Map<String, String> results = new HashMap<>();
+        while (paginatedMapping.next()) {
+            final Map<String, String> mappings = paginatedMapping.getMapping();
+            for (Map.Entry<String, String> entry : mappings.entrySet()) {
+                String serverUserKey = entry.getKey();
+                String cloudUserKey = entry.getValue();
+                if (serverUserKey.startsWith(USER_MAPPING_PREFIX)) {
+                    results.put(serverUserKey, cloudUserKey);
+                }
+            }
+        }
+        return Collections.unmodifiableMap(results);
     }
 
     /**
@@ -32,7 +71,7 @@ class UserService {
      * <li>Space is public and allows anonymous access (global space permission) OR</li>
      * <li>Space is not editable entirely, such config is uncommon</li>
      */
-    String pickUserWhoHasEditPerm(
+    private String pickUserWhoHasEditPerm(
             PageData pageData,
             Map<Long, Set<UserKey>> spacePermissions,
             Map<String, Set<UserKey>> pageRestrictions,
@@ -54,24 +93,5 @@ class UserService {
                 .filter(Objects::nonNull)
                 .findAny()
                 .orElse(null);
-    }
-
-    /**
-     * User mapping from server id to cloud id.
-     */
-    Map<String, String> getUserMap(AppCloudMigrationGateway gateway, String transferId) {
-        final PaginatedMapping paginatedMapping = gateway.getPaginatedMapping(transferId, "identity:user", BATCH_SIZE);
-        final Map<String, String> results = new HashMap<>();
-        while (paginatedMapping.next()) {
-            final Map<String, String> mappings = paginatedMapping.getMapping();
-            for (Map.Entry<String, String> entry : mappings.entrySet()) {
-                String serverUserKey = entry.getKey();
-                String cloudUserKey = entry.getValue();
-                if (serverUserKey.startsWith(USER_MAPPING_PREFIX)) {
-                    results.put(serverUserKey, cloudUserKey);
-                }
-            }
-        }
-        return Collections.unmodifiableMap(results);
     }
 }

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/UserService.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/UserService.java
@@ -1,27 +1,35 @@
 package com.atlassian.plugins.confluence.markdown.ccma;
 
+import com.atlassian.confluence.user.ConfluenceUser;
+import com.atlassian.confluence.user.UserAccessor;
 import com.atlassian.migration.app.PaginatedMapping;
 import com.atlassian.migration.app.gateway.AppCloudMigrationGateway;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ConfluenceImport;
 import com.atlassian.sal.api.user.UserKey;
+import com.atlassian.user.Group;
 import org.apache.commons.collections4.SetUtils;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.*;
+import java.util.stream.StreamSupport;
 
 @Named
 class UserService {
     private static final String USER_MAPPING_PREFIX = "confluence.userkey/";
     private static final int BATCH_SIZE = 5;
 
+    private final UserAccessor userAccessor;
     private final SpacePermissionService spacePermissionService;
     private final PageRestrictionService pageRestrictionService;
 
     @Inject
     UserService(
+            @ConfluenceImport UserAccessor userAccessor,
             SpacePermissionService spacePermissionService,
             PageRestrictionService pageRestrictionService
     ) {
+        this.userAccessor = userAccessor;
         this.spacePermissionService = spacePermissionService;
         this.pageRestrictionService = pageRestrictionService;
     }
@@ -31,11 +39,12 @@ class UserService {
      */
     void enrichCloudUser(AppCloudMigrationGateway gateway, String transferId, List<PageData> pageDataList) {
         final Map<String, String> userMap = getUserMap(gateway, transferId);
-        final Map<Long, Set<UserKey>> spacePermissions = spacePermissionService.getPermissions(pageDataList);
-        final Map<String, Set<UserKey>> pageRestrictions = pageRestrictionService.getPermissions(pageDataList);
+        final Map<Long, PermData> spacePermissions = spacePermissionService.getPermissions(pageDataList);
+        final Map<String, PermData> pageRestrictions = pageRestrictionService.getPermissions(pageDataList);
 
+        final Helper helper = new Helper();
         for (PageData pageData : pageDataList) {
-            final String cloudUserKey = pickUserWhoHasEditPerm(pageData, spacePermissions, pageRestrictions, userMap);
+            final String cloudUserKey = helper.pickUserWhoHasEditPerm(pageData, spacePermissions, pageRestrictions, userMap);
             pageData.setCloudUserKey(cloudUserKey);
         }
     }
@@ -60,38 +69,125 @@ class UserService {
     }
 
     /**
-     * Pick a user who has edit permission on page.
-     *
-     * If a page is restricted then pick a user who has edit perm in
-     * both page and space.
-     *
-     * If a page is not restricted then pick a user from space restriction settings.
-     *
-     * Return null if:
-     * <li>Space is public and allows anonymous access (global space permission) OR</li>
-     * <li>Space is not editable entirely, such config is uncommon</li>
+     * User picker implementation with cache.
      */
-    private String pickUserWhoHasEditPerm(
-            PageData pageData,
-            Map<Long, Set<UserKey>> spacePermissions,
-            Map<String, Set<UserKey>> pageRestrictions,
-            Map<String, String> userMap
-    ) {
-        final long spaceId = pageData.getServerSpaceId();
-        final Set<UserKey> pageRestrictedUsers = pageRestrictions.getOrDefault(pageData.getServerId(), Collections.emptySet());
-        final Set<UserKey> spaceRestrictedUsers = spacePermissions.getOrDefault(spaceId, Collections.emptySet());
+    private class Helper {
+        final Map<String, Optional<UserKey>> userByGroupCache = new HashMap<>();
+        final Map<UserKey, Set<String>> groupsByUserCache = new HashMap<>();
 
-        final Set<UserKey> satisfiedUsers = pageRestrictedUsers.isEmpty()
-                ? spaceRestrictedUsers
-                : SetUtils.intersection(spaceRestrictedUsers, pageRestrictedUsers);
+        /**
+         * Pick a user who has edit permission on page.
+         *
+         * If a page is restricted then pick a user who has edit perm in
+         * both page and space.
+         *
+         * If a page is not restricted then pick a user from space restriction settings.
+         *
+         * Return null if:
+         * <li>Space is public and allows anonymous access (global space permission) OR</li>
+         * <li>Space is not editable entirely, such config is uncommon</li>
+         */
+        private String pickUserWhoHasEditPerm(
+                PageData pageData,
+                Map<Long, PermData> spacePermissions,
+                Map<String, PermData> pageRestrictions,
+                Map<String, String> userMap
+        ) {
+            final long spaceId = pageData.getServerSpaceId();
+            final PermData pagePermission = pageRestrictions.getOrDefault(pageData.getServerId(), PermData.empty);
+            final PermData spacePermission = spacePermissions.getOrDefault(spaceId, PermData.empty);
 
-        return satisfiedUsers
-                .stream()
-                .map(UserKey::getStringValue)
-                .map(USER_MAPPING_PREFIX::concat)
-                .map(userMap::get)
-                .filter(Objects::nonNull)
-                .findAny()
-                .orElse(null);
+            Optional<UserKey> userKeyOpt;
+            if (pagePermission.isEmpty()) {
+                userKeyOpt = pickUserFromSpace(spacePermission);
+            } else {
+                final Set<UserKey> pageUsers = pagePermission.getUsers();
+                final Set<String> pageGroups = pagePermission.getGroups();
+
+                final Set<UserKey> spaceUsers = spacePermission.getUsers();
+                final Set<String> spaceGroups = spacePermission.getGroups();
+
+                userKeyOpt = pickCommonUser(pageUsers, spaceUsers);
+
+                if (!userKeyOpt.isPresent()) {
+                    userKeyOpt = pickUserIfInGroup(pageUsers, spaceGroups);
+                }
+
+                if (!userKeyOpt.isPresent()) {
+                    userKeyOpt = pickUserIfInGroup(spaceUsers, pageGroups);
+                }
+
+                if (!userKeyOpt.isPresent()) {
+                    userKeyOpt = pickUserInCommonGroup(pageGroups, spaceGroups);
+                }
+            }
+
+            return userKeyOpt
+                    .map(UserKey::getStringValue)
+                    .map(USER_MAPPING_PREFIX::concat)
+                    .map(userMap::get)
+                    .orElse(null);
+        }
+
+        private Optional<UserKey> pickUserFromSpace(PermData spacePermission) {
+            final Optional<UserKey> userKey = spacePermission.getUsers().stream().findAny();
+            if (userKey.isPresent()) {
+                return userKey;
+            } else {
+                return pickUserInGroups(spacePermission.getGroups());
+            }
+        }
+
+        private Optional<UserKey> pickCommonUser(Set<UserKey> pageUsers, Set<UserKey> spaceUsers) {
+            return SetUtils
+                    .intersection(pageUsers, spaceUsers)
+                    .stream()
+                    .findAny();
+        }
+
+        private Optional<UserKey> pickUserIfInGroup(Set<UserKey> userKeys, Set<String> groups) {
+            return userKeys.stream().filter(userKey -> {
+                final Set<String> userGroups = getUserGroups(userKey);
+                return !SetUtils.intersection(userGroups, groups).isEmpty();
+            }).findFirst();
+        }
+
+        private Optional<UserKey> pickUserInCommonGroup(Set<String> pageGroups, Set<String> spaceGroups) {
+            final Set<String> commonGroups = SetUtils.intersection(pageGroups, spaceGroups);
+            return pickUserInGroups(commonGroups);
+        }
+
+        private Optional<UserKey> pickUserInGroups(Set<String> groups) {
+            return groups
+                    .stream()
+                    .map(this::pickUserInGroup)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .findFirst();
+        }
+
+        private Optional<UserKey> pickUserInGroup(String groupName) {
+            return userByGroupCache.computeIfAbsent(groupName, __ -> {
+                final Group group = userAccessor.getGroup(groupName);
+                final Spliterator<ConfluenceUser> spliterator = Spliterators.spliteratorUnknownSize(
+                        userAccessor.getMembers(group).iterator(),
+                        Spliterator.ORDERED
+                );
+                return StreamSupport.stream(spliterator, false)
+                        .map(ConfluenceUser::getKey)
+                        .findFirst();
+            });
+        }
+
+        private Set<String> getUserGroups(UserKey userKey) {
+            return groupsByUserCache.computeIfAbsent(userKey, __ -> {
+                final ConfluenceUser user = userAccessor.getUserByKey(userKey);
+                if (user == null) {
+                    return Collections.emptySet();
+                }
+
+                return new HashSet<>(userAccessor.getGroupNames(user));
+            });
+        }
     }
 }

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/UserService.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/ccma/UserService.java
@@ -1,0 +1,77 @@
+package com.atlassian.plugins.confluence.markdown.ccma;
+
+import com.atlassian.confluence.user.UserAccessor;
+import com.atlassian.migration.app.PaginatedMapping;
+import com.atlassian.migration.app.gateway.AppCloudMigrationGateway;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ConfluenceImport;
+import com.atlassian.sal.api.user.UserKey;
+import org.apache.commons.collections4.SetUtils;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.*;
+
+@Named
+class UserService {
+    private static final String USER_MAPPING_PREFIX = "confluence.userkey/";
+    private static final int BATCH_SIZE = 5;
+
+    @Inject
+    UserService(@ConfluenceImport UserAccessor userAccessor) {
+    }
+
+    /**
+     * Pick a user who has edit permission on page.
+     *
+     * If a page is restricted then pick a user who has edit perm in
+     * both page and space.
+     *
+     * If a page is not restricted then pick a user from space restriction settings.
+     *
+     * Return null if:
+     * <li>Space is public and allows anonymous access (global space permission) OR</li>
+     * <li>Space is not editable entirely, such config is uncommon</li>
+     */
+    String pickUserWhoHasEditPerm(
+            PageData pageData,
+            Map<Long, Set<UserKey>> spacePermissions,
+            Map<String, Set<UserKey>> pageRestrictions,
+            Map<String, String> userMap
+    ) {
+        final long spaceId = pageData.getServerSpaceId();
+        final Set<UserKey> pageRestrictedUsers = pageRestrictions.getOrDefault(pageData.getServerId(), Collections.emptySet());
+        final Set<UserKey> spaceRestrictedUsers = spacePermissions.getOrDefault(spaceId, Collections.emptySet());
+
+        final Set<UserKey> satisfiedUsers = pageRestrictedUsers.isEmpty()
+                ? spaceRestrictedUsers
+                : SetUtils.intersection(spaceRestrictedUsers, pageRestrictedUsers);
+
+        return satisfiedUsers
+                .stream()
+                .map(UserKey::getStringValue)
+                .map(USER_MAPPING_PREFIX::concat)
+                .map(userMap::get)
+                .filter(Objects::nonNull)
+                .findAny()
+                .orElse(null);
+    }
+
+    /**
+     * User mapping from server id to cloud id.
+     */
+    Map<String, String> getUserMap(AppCloudMigrationGateway gateway, String transferId) {
+        final PaginatedMapping paginatedMapping = gateway.getPaginatedMapping(transferId, "identity:user", BATCH_SIZE);
+        final Map<String, String> results = new HashMap<>();
+        while (paginatedMapping.next()) {
+            final Map<String, String> mappings = paginatedMapping.getMapping();
+            for (Map.Entry<String, String> entry : mappings.entrySet()) {
+                String serverUserKey = entry.getKey();
+                String cloudUserKey = entry.getValue();
+                if (serverUserKey.startsWith(USER_MAPPING_PREFIX)) {
+                    results.put(serverUserKey, cloudUserKey);
+                }
+            }
+        }
+        return Collections.unmodifiableMap(results);
+    }
+}

--- a/src/main/java/com/atlassian/plugins/confluence/markdown/configuration/Config.java
+++ b/src/main/java/com/atlassian/plugins/confluence/markdown/configuration/Config.java
@@ -1,0 +1,13 @@
+package com.atlassian.plugins.confluence.markdown.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+
+@Configuration
+public class Config {
+    @Bean
+    public static PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
+        return new PropertySourcesPlaceholderConfigurer();
+    }
+}

--- a/src/main/resources/META-INF/spring/plugin-context.xml
+++ b/src/main/resources/META-INF/spring/plugin-context.xml
@@ -7,4 +7,7 @@
         http://www.atlassian.com/schema/atlassian-scanner/2
         http://www.atlassian.com/schema/atlassian-scanner/2/atlassian-scanner.xsd">
     <atlassian-scanner:scan-indexes/>
+    <bean class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer">
+        <property name="location" value="confluence-markdown-macro.properties"/>
+    </bean>
 </beans>

--- a/src/main/resources/confluence-markdown-macro.properties
+++ b/src/main/resources/confluence-markdown-macro.properties
@@ -2,3 +2,4 @@
 my.plugin.name=Markdown
 com.atlassian.plugins.confluence.markdown.admin.section.label=Markdown Macro
 com.atlassian.plugins.confluence.markdown.admin.config.label=Configuration
+build.version=@project.version@


### PR DESCRIPTION
Within this PR, migration payload now include a user who has edit permission on that page. Cloud side will fetch and update page on behalf of that user (impersonating). This is to bypass Atlassian bug [MIG-905](https://jira.atlassian.com/browse/MIG-905).

The logic to get a user who has edit permission on a page is based on:
- Permission on page is controlled by space permission and page restrictions
- Edit restrictions on a page do NOT cascade to its child pages. That means a user can edit a page even though he does not have edit permission on parent page.
- Edit permissions on a space DO cascade to its pages. That means a user must have edit permission at space level in order to edit space's pages. Granting edit permission on a page but not the space will not work.

So to get a user who has edit permission on a page:
- get all users who are restricted to edit on that page (1)
- get all users who has edit permission at space level (2)
- if (1) is empty then pick a user from (2)
- if (1) is NOT empty then pick a user who appear in both (1) & (2)

Note that if a space is entirely read only (non-public and neither grant edit perm for group nor user), there is no way to edit its content. There is nothing we can do in this case.

All permission related code is sealed in package-private `UserPermission` class. It makes things easier to remove in the future when Atlassian fix the issue on their side.

@bberenberg There are a few points you might need to know:
- On cloud side we need to add [`ACT_AS_USER`](https://developer.atlassian.com/cloud/confluence/user-impersonation-for-connect-apps/) scope to the app.
- On server side we need to request [`MIGRATION_TRACING_IDENTITY`](https://developer.atlassian.com/platform/app-migration/access-scopes/) scope
User/Atlassian might question why we request these scopes.