### PR TITLE
Release to marketplace

### DIFF
--- a/.github/actions/marketplace/action.yml
+++ b/.github/actions/marketplace/action.yml
@@ -1,0 +1,117 @@
+name: 'Release to marketplace'
+description: 'Release new app version to marketplace'
+inputs:
+  filePath:
+    description: 'Path to the jar file'
+    required: true
+  fileName:
+    description: 'jar file name'
+    required: true
+  version:
+    description: 'The new app version'
+    required: true
+  marketplaceToken:
+    description: 'The marketplace token'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Set marketplace base URL
+      id: mp_base_url
+      run: echo "::set-output name=value::https://marketplace.atlassian.com"
+      shell: bash
+
+    - name: Get marketplace info
+      id: mp_info
+      uses: fjogeleit/http-request-action@master
+      with:
+        url: '${{ steps.mp_base_url.outputs.value }}/rest/2'
+        method: 'GET'
+
+    - name: Extract marketplace endpoints
+      id: mp_endpoint
+      run: |
+        echo "::set-output name=assets::${{ fromJSON(steps.mp_info.outputs.response)._links.assets.href }}"
+        echo "::set-output name=addons::${{ fromJSON(steps.mp_info.outputs.response)._links.addons.href }}"
+      shell: bash
+
+    - name: Get marketplace asset info
+      id: mp_asset_info
+      uses: fjogeleit/http-request-action@master
+      with:
+        url: '${{ steps.mp_base_url.outputs.value }}${{ steps.mp_endpoint.outputs.assets }}'
+        method: 'GET'
+
+    - name: Extract marketplace artifact endpoint
+      id: mp_artifact_endpoint
+      run: echo "::set-output name=value::${{ fromJSON(steps.mp_asset_info.outputs.response)._links.artifact.href }}"
+      shell: bash
+
+    - name: Upload to marketplace
+      id: mp_upload
+      uses: nhan-nguyen-se/http-request-action@master
+      with:
+        url: '${{ steps.mp_base_url.outputs.value }}${{ steps.mp_artifact_endpoint.outputs.value }}?file=${{ inputs.fileName }}'
+        method: 'POST'
+        contentType: 'application/octet-stream'
+        username: 'devops@atlasauthority.com'
+        password: ${{ inputs.marketplaceToken }}
+        file: ${{ inputs.filePath }}
+
+    - name: Extract marketplace upload endpoint
+      id: mp_upload_endpoint
+      run: echo "::set-output name=value::${{ fromJSON(steps.mp_upload.outputs.response)._links.self.href }}"
+      shell: bash
+
+    - name: Get marketplace addons APIs
+      id: mp_addon_api
+      uses: fjogeleit/http-request-action@master
+      with:
+        url: '${{ steps.mp_base_url.outputs.value }}${{ steps.mp_endpoint.outputs.addons }}?limit=0'
+        method: 'GET'
+
+    - name: Extract marketplace addon endpoint template
+      id: mp_addon_endpoint_template
+      run: echo "::set-output name=value::${{ fromJSON(steps.mp_addon_api.outputs.response)._links.byKey.href }}"
+      shell: bash
+
+    - name: Build marketplace addon endpoint
+      id: mp_addon_endpoint
+      uses: frabert/replace-string-action@v2.0
+      with:
+        pattern: '{addonKey}'
+        string: ${{ steps.mp_addon_endpoint_template.outputs.value }}
+        replace-with: 'com.atlassian.plugins.confluence.markdown.confluence-markdown-macro'
+
+    - name: Get marketplace addons info
+      id: mp_addon_info
+      uses: fjogeleit/http-request-action@master
+      with:
+        url: '${{ steps.mp_base_url.outputs.value }}${{ steps.mp_addon_endpoint.outputs.replaced }}'
+        method: 'GET'
+
+    - name: Extract marketplace addons version endpoint
+      id: mp_addon_version_endpoint
+      run: echo "::set-output name=value::${{ fromJSON(steps.mp_addon_info.outputs.response)._links.versions.href }}"
+      shell: bash
+
+    - name: Update marketplace version
+      uses: fjogeleit/http-request-action@master
+      with:
+        url: '${{ steps.mp_base_url.outputs.value }}${{ steps.mp_addon_version_endpoint.outputs.value }}'
+        method: 'POST'
+        contentType: 'application/json'
+        username: 'devops@atlasauthority.com'
+        password: ${{ inputs.marketplaceToken }}
+        data: '{ "_links": { "artifact": { "href": "${{ steps.mp_upload_endpoint.outputs.value }}" } }, "status": "private", "name": "${{ steps.get_tag_version.outputs.value }}" }'
+
+    - name: Bump required version for migration
+      uses: fjogeleit/http-request-action@master
+      with:
+        url: '${{ steps.mp_base_url.outputs.value }}${{ steps.mp_addon_endpoint.outputs.replaced }}/migration'
+        method: 'PATCH'
+        contentType: 'application/json-patch+json'
+        username: 'devops@atlasauthority.com'
+        password: ${{ inputs.marketplaceToken }}
+        data: '[{ "op": "replace", "path": "/cloudMigrationAssistantCompatibility", "value": "${{ steps.get_tag_version.outputs.value }}" }]'
+      if: steps.should_bump_version.outputs.value == 'true'

--- a/.github/actions/marketplace/action.yml
+++ b/.github/actions/marketplace/action.yml
@@ -1,6 +1,10 @@
+# This implementation is based on https://developer.atlassian.com/platform/marketplace/listing-an-app-version-using-rest/
 name: 'Release to marketplace'
 description: 'Release new app version to marketplace'
 inputs:
+  addonKey:
+    description: 'Addon key'
+    required: true
   filePath:
     description: 'Path to the jar file'
     required: true
@@ -49,7 +53,7 @@ runs:
 
     - name: Upload to marketplace
       id: mp_upload
-      uses: nhan-nguyen-se/http-request-action@master
+      uses: Atlas-Authority/http-request-action@master
       with:
         url: '${{ steps.mp_base_url.outputs.value }}${{ steps.mp_artifact_endpoint.outputs.value }}?file=${{ inputs.fileName }}'
         method: 'POST'
@@ -81,13 +85,15 @@ runs:
       with:
         pattern: '{addonKey}'
         string: ${{ steps.mp_addon_endpoint_template.outputs.value }}
-        replace-with: 'com.atlassian.plugins.confluence.markdown.confluence-markdown-macro'
+        replace-with: ${{ inputs.addonKey }}
 
     - name: Get marketplace addons info
       id: mp_addon_info
       uses: fjogeleit/http-request-action@master
       with:
         url: '${{ steps.mp_base_url.outputs.value }}${{ steps.mp_addon_endpoint.outputs.replaced }}'
+        username: 'devops@atlasauthority.com'
+        password: ${{ inputs.marketplaceToken }}
         method: 'GET'
 
     - name: Extract marketplace addons version endpoint
@@ -95,7 +101,8 @@ runs:
       run: echo "::set-output name=value::${{ fromJSON(steps.mp_addon_info.outputs.response)._links.versions.href }}"
       shell: bash
 
-    - name: Update marketplace version
+    - name: Create new marketplace version
+      id: 'create_mp_version_res'
       uses: fjogeleit/http-request-action@master
       with:
         url: '${{ steps.mp_base_url.outputs.value }}${{ steps.mp_addon_version_endpoint.outputs.value }}'
@@ -103,9 +110,15 @@ runs:
         contentType: 'application/json'
         username: 'devops@atlasauthority.com'
         password: ${{ inputs.marketplaceToken }}
-        data: '{ "_links": { "artifact": { "href": "${{ steps.mp_upload_endpoint.outputs.value }}" } }, "status": "private", "name": "${{ steps.get_tag_version.outputs.value }}" }'
+        timeout: '30000'
+        data: '{ "_links": { "artifact": { "href": "${{ steps.mp_upload_endpoint.outputs.value }}" } }, "status": "private", "name": "${{ inputs.version }}" }'
+
+    - name: Print app version creation response
+      run: echo ${{ steps.create_mp_version_res.outputs.response }}
+      shell: bash
 
     - name: Bump required version for migration
+      id: 'bump_migration_version_res'
       uses: fjogeleit/http-request-action@master
       with:
         url: '${{ steps.mp_base_url.outputs.value }}${{ steps.mp_addon_endpoint.outputs.replaced }}/migration'
@@ -113,5 +126,9 @@ runs:
         contentType: 'application/json-patch+json'
         username: 'devops@atlasauthority.com'
         password: ${{ inputs.marketplaceToken }}
-        data: '[{ "op": "replace", "path": "/cloudMigrationAssistantCompatibility", "value": "${{ steps.get_tag_version.outputs.value }}" }]'
-      if: steps.should_bump_version.outputs.value == 'true'
+        timeout: '30000'
+        data: '[{ "op": "replace", "path": "/cloudMigrationAssistantCompatibility", "value": "${{ inputs.version }}" }]'
+
+    - name: Print bump migration version response
+      run: echo ${{ steps.bump_migration_version_res.outputs.response }}
+      shell: bash

--- a/.github/actions/marketplace/action.yml
+++ b/.github/actions/marketplace/action.yml
@@ -27,7 +27,7 @@ runs:
 
     - name: Get marketplace info
       id: mp_info
-      uses: fjogeleit/http-request-action@master
+      uses: fjogeleit/http-request-action@v1.8.2
       with:
         url: '${{ steps.mp_base_url.outputs.value }}/rest/2'
         method: 'GET'
@@ -41,7 +41,7 @@ runs:
 
     - name: Get marketplace asset info
       id: mp_asset_info
-      uses: fjogeleit/http-request-action@master
+      uses: fjogeleit/http-request-action@v1.8.2
       with:
         url: '${{ steps.mp_base_url.outputs.value }}${{ steps.mp_endpoint.outputs.assets }}'
         method: 'GET'
@@ -69,7 +69,7 @@ runs:
 
     - name: Get marketplace addons APIs
       id: mp_addon_api
-      uses: fjogeleit/http-request-action@master
+      uses: fjogeleit/http-request-action@v1.8.2
       with:
         url: '${{ steps.mp_base_url.outputs.value }}${{ steps.mp_endpoint.outputs.addons }}?limit=0'
         method: 'GET'
@@ -89,7 +89,7 @@ runs:
 
     - name: Get marketplace addons info
       id: mp_addon_info
-      uses: fjogeleit/http-request-action@master
+      uses: fjogeleit/http-request-action@v1.8.2
       with:
         url: '${{ steps.mp_base_url.outputs.value }}${{ steps.mp_addon_endpoint.outputs.replaced }}'
         username: 'devops@atlasauthority.com'
@@ -103,7 +103,7 @@ runs:
 
     - name: Create new marketplace version
       id: 'create_mp_version_res'
-      uses: fjogeleit/http-request-action@master
+      uses: fjogeleit/http-request-action@v1.8.2
       with:
         url: '${{ steps.mp_base_url.outputs.value }}${{ steps.mp_addon_version_endpoint.outputs.value }}'
         method: 'POST'
@@ -119,7 +119,7 @@ runs:
 
     - name: Bump required version for migration
       id: 'bump_migration_version_res'
-      uses: fjogeleit/http-request-action@master
+      uses: fjogeleit/http-request-action@v1.8.2
       with:
         url: '${{ steps.mp_base_url.outputs.value }}${{ steps.mp_addon_endpoint.outputs.replaced }}/migration'
         method: 'PATCH'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,15 @@ jobs:
       - name: Print should bump version
         run: echo ${{ steps.should_bump_version.outputs.value }}
 
+      - name: Release to marketplace
+        uses: ./.github/actions/marketplace
+        with:
+          filePath: target/${{ steps.get_jar_file.outputs.name }}
+          fileName: ${{ steps.get_jar_file.outputs.name }}
+          version: ${{ steps.get_tag_version.outputs.value }}
+          marketplaceToken: ${{ secrets.MARKETPLACE_TOKEN }}
+        if: steps.should_bump_version.outputs.value == 'true'
+
       # This is a side effect action, let do it last
       - name: Commit the changes to pom.xml
         run: |
@@ -131,15 +140,4 @@ jobs:
           git add pom.xml
           git commit -m "Bumped version to ${{ steps.get_tag_version.outputs.value }}"
           git push
-        if: steps.should_bump_version.outputs.value == 'true'
-      
-      - name: Bump required version for migration
-        uses: fjogeleit/http-request-action@master
-        with:
-          url: 'https://marketplace.atlassian.com/rest/2/addons/com.atlassian.plugins.confluence.markdown.confluence-markdown-macro/migration'
-          method: 'PATCH'
-          contentType: 'application/json-patch+json'
-          username: 'devops@atlasauthority.com'
-          password: ${{ secrets.MARKETPLACE_TOKEN }}
-          data: '[{ "op": "replace", "path": "/cloudMigrationAssistantCompatibility", "value": "${{ steps.get_tag_version.outputs.value }}" }]'
         if: steps.should_bump_version.outputs.value == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,7 @@ jobs:
       - name: Release to marketplace
         uses: ./.github/actions/marketplace
         with:
+          addonKey: 'com.atlassian.plugins.confluence.markdown.confluence-markdown-macro'
           filePath: target/${{ steps.get_jar_file.outputs.name }}
           fileName: ${{ steps.get_jar_file.outputs.name }}
           version: ${{ steps.get_tag_version.outputs.value }}


### PR DESCRIPTION
Close #58 

@bberenberg 

I just created this DRAFT PR for easy discuss. Automating marketplace release is more complex than we think. Basically we need to:
1. upload jar file to marketplace and get back the download link
2. create new app version with that download link
3. bump migration required version

(Please check this [link](https://developer.atlassian.com/platform/marketplace/listing-an-app-version-using-rest/) for full steps.)

For step 1 I can't find an action on GitHub Marketplace to do it. There are many http client action out there but all of them using `multipart/form-data` content type. Atlassian requires `application/octet-stream`. So I have to fork a [repo](https://github.com/nhan-nguyen-se/http-request-action) and make some changes to fit with our needs. Let me know if it is OK and:
- I should move it to Atlas-Authority org
- I should contribute an PR back to the upstream. It requires extra time to work on (update their docs and unit test)

I'm a bit concern because I can't test it the whole. There are 3 APIs require authentication. For those APIs which does not requires auth I tested them already.